### PR TITLE
Added URL encoding for the query

### DIFF
--- a/lib/google-search.coffee
+++ b/lib/google-search.coffee
@@ -6,5 +6,6 @@ module.exports =
     query  = atom.workspace.getActivePaneItem().getLastSelection().getText()
 
     if query
+      query = encodeURIComponent(query)
       url = "https://encrypted.google.com/search?q=#{query}&oq=#{query}"
       window.open(url, "#{query} - Google Search", "status=0, toolbar=0")


### PR DESCRIPTION
The URL must be encoded to support special characters like @, #, &, etc. If this is not done, queries like "#import ..." result in the query not being done.